### PR TITLE
Add basic Bitrunner Bitnode definition

### DIFF
--- a/src/BitNode/BitNode.tsx
+++ b/src/BitNode/BitNode.tsx
@@ -437,7 +437,38 @@ BitNodes["BitNode13"] = new BitNode(
       Each level of this Source-File increases the size of Stanek's Gift.
     </>
   ),
-);
+  );
+  BitNodes["BitNode14"] = new BitNode(
+    14,
+    2,
+    "Bitrunner",
+    "There is no reward without risk",
+    (
+      <>
+        "His eyes were eggs of unstable crystal, vibrating with a frequency whose name was rain and the sound of trains, suddenly sprouting a humming forest of hair-fine glass spines."
+        <br />
+        ― William Gibson, Neuromancer
+        <br />
+        <br />
+        There is no reward without risk.
+        Servers in this BitNode are protected by powerful defense mechanisms able to kill hackers who approach unprepared.
+        Additional tools are available which will allow you to succeed.
+        Careful planning and execution will be required in order to escape your chains.
+        <br />
+        <br />
+        In this test version of the game you have two hours to succeed or fail.
+        Every method of earning that isn't hacking has been nerfed to the ground.
+        Good luck!
+        <br />
+        <br />
+        Destroying this BitNode will give you Source-File N,
+        or if you already have this Source-File it will upgrade its level up to a maximum of 3.
+        <br />
+        <br />
+        [Insert explanation of unique reward here]
+      </>
+    ),
+  );
 
 export const defaultMultipliers: IBitNodeMultipliers = {
   HackingLevelMultiplier: 1,
@@ -860,6 +891,9 @@ export function getBitNodeMultipliers(n: number, lvl: number): IBitNodeMultiplie
         WorldDaemonDifficulty: 3,
         GangUniqueAugs: 0.1,
       });
+    }
+    case 14: {
+      return mults;
     }
     default: {
       throw new Error("Invalid BitNodeN");

--- a/src/BitNode/ui/BitverseRoot.tsx
+++ b/src/BitNode/ui/BitverseRoot.tsx
@@ -234,7 +234,7 @@ export function BitverseRoot(props: IProps): React.ReactElement {
       <Typography sx={{lineHeight: '1em',whiteSpace: 'pre'}}>O | | |  \|  |  O  /   _/ |    /    O  |  |/  | | | O</Typography>
       <Typography sx={{lineHeight: '1em',whiteSpace: 'pre'}}>| | | |O  /  |  | O   /   |   O   O |  |  \  O| | | |</Typography>
       <Typography sx={{lineHeight: '1em',whiteSpace: 'pre'}}>| | |/  \/  / __| | |/ \  |   \   | |__ \  \/  \| | |</Typography>
-      <Typography sx={{lineHeight: '1em',whiteSpace: 'pre'}}> \| O   |  |_/    |\|   \ <BitNodePortal n={13} level={n(13)} enter={enter} flume={props.flume} destroyedBitNode={destroyed} />    \__|    \_|  |   O |/ </Typography>
+      <Typography sx={{lineHeight: '1em',whiteSpace: 'pre'}}> \| <BitNodePortal n={13} level={n(13)} enter={enter} flume={props.flume} destroyedBitNode={destroyed} />   |  |_/    |\|   \ <BitNodePortal n={14} level={n(14)} enter={enter} flume={props.flume} destroyedBitNode={destroyed} />    \__|    \_|  |   O |/ </Typography>
       <Typography sx={{lineHeight: '1em',whiteSpace: 'pre'}}>  | |   |_/       | |    \|    /  |       \_|   | |  </Typography>
       <Typography sx={{lineHeight: '1em',whiteSpace: 'pre'}}>   \|   /          \|     |   /  /          \   |/   </Typography>
       <Typography sx={{lineHeight: '1em',whiteSpace: 'pre'}}>    |  <BitNodePortal n={10} level={n(10)} enter={enter} flume={props.flume} destroyedBitNode={destroyed} />            |     |  /  |            <BitNodePortal n={11} level={n(11)} enter={enter} flume={props.flume} destroyedBitNode={destroyed} />  |    </Typography>

--- a/src/Bitrunner/ServerExtension.ts
+++ b/src/Bitrunner/ServerExtension.ts
@@ -1,0 +1,11 @@
+import { ServerExtension } from "../Server/ServerExtension";
+import { bitrunnerServerData } from "./data/servers";
+
+export class BitrunnerServerExtension extends ServerExtension {
+  proxyHealth : number;
+
+  constructor(serverName : string) {
+    super();
+    this.proxyHealth = bitrunnerServerData[serverName].proxyHealth;
+  }
+}

--- a/src/Bitrunner/data/servers.ts
+++ b/src/Bitrunner/data/servers.ts
@@ -1,0 +1,212 @@
+export const bitrunnerServerData : Record<string, Record<string, number>> = {
+  "ecorp": {
+    "proxyHealth": 0
+  },
+  "megacorp": {
+    "proxyHealth": 0
+  },
+  "b-and-a": {
+    "proxyHealth": 0
+  },
+  "blade": {
+    "proxyHealth": 0
+  },
+  "nwo": {
+    "proxyHealth": 0
+  },
+  "clarkinc": {
+    "proxyHealth": 0
+  },
+  "omnitek": {
+    "proxyHealth": 0
+  },
+  "4sigma": {
+    "proxyHealth": 0
+  },
+  "kuai-gong": {
+    "proxyHealth": 0
+  },
+  "fulcrumtech": {
+    "proxyHealth": 0
+  },
+  "fulcrumassets": {
+    "proxyHealth": 0
+  },
+  "stormtech": {
+    "proxyHealth": 0
+  },
+  "defcomm": {
+    "proxyHealth": 0
+  },
+  "infocomm": {
+    "proxyHealth": 0
+  },
+  "helios": {
+    "proxyHealth": 0
+  },
+  "vitalife": {
+    "proxyHealth": 0
+  },
+  "icarus": {
+    "proxyHealth": 0
+  },
+  "univ-energy": {
+    "proxyHealth": 0
+  },
+  "titan-labs": {
+    "proxyHealth": 0
+  },
+  "microdyne": {
+    "proxyHealth": 0
+  },
+  "taiyang-digital": {
+    "proxyHealth": 0
+  },
+  "galactic-cyber": {
+    "proxyHealth": 0
+  },
+  "aerocorp": {
+    "proxyHealth": 0
+  },
+  "omnia": {
+    "proxyHealth": 0
+  },
+  "zb-def": {
+    "proxyHealth": 0
+  },
+  "applied-energetics": {
+    "proxyHealth": 0
+  },
+  "solaris": {
+    "proxyHealth": 0
+  },
+  "deltaone": {
+    "proxyHealth": 0
+  },
+  "global-pharm": {
+    "proxyHealth": 0
+  },
+  "nova-med": {
+    "proxyHealth": 0
+  },
+  "zeus-med": {
+    "proxyHealth": 0
+  },
+  "unitalife": {
+    "proxyHealth": 0
+  },
+  "lexo-corp": {
+    "proxyHealth": 0
+  },
+  "rho-construction": {
+    "proxyHealth": 0
+  },
+  "alpha-ent": {
+    "proxyHealth": 0
+  },
+  "aevum-police": {
+    "proxyHealth": 0
+  },
+  "rothman-uni": {
+    "proxyHealth": 0
+  },
+  "zb-institute": {
+    "proxyHealth": 0
+  },
+  "summit-uni": {
+    "proxyHealth": 0
+  },
+  "syscore": {
+    "proxyHealth": 0
+  },
+  "catalyst": {
+    "proxyHealth": 0
+  },
+  "the-hub": {
+    "proxyHealth": 0
+  },
+  "computek": {
+    "proxyHealth": 0
+  },
+  "netlink": {
+    "proxyHealth": 0
+  },
+  "johnson-ortho": {
+    "proxyHealth": 0
+  },
+  "n00dles": {
+    "proxyHealth": 0
+  },
+  "foodnstuff": {
+    "proxyHealth": 0
+  },
+  "sigma-cosmetics": {
+    "proxyHealth": 0
+  },
+  "joesguns": {
+    "proxyHealth": 0
+  },
+  "zer0": {
+    "proxyHealth": 0
+  },
+  "nectar-net": {
+    "proxyHealth": 0
+  },
+  "neo-net": {
+    "proxyHealth": 0
+  },
+  "silver-helix": {
+    "proxyHealth": 0
+  },
+  "hong-fang-tea": {
+    "proxyHealth": 0
+  },
+  "harakiri-sushi": {
+    "proxyHealth": 0
+  },
+  "phantasy": {
+    "proxyHealth": 0
+  },
+  "max-hardware": {
+    "proxyHealth": 0
+  },
+  "omega-net": {
+    "proxyHealth": 0
+  },
+  "crush-fitness": {
+    "proxyHealth": 0
+  },
+  "iron-gym": {
+    "proxyHealth": 0
+  },
+  "millenium-fitness": {
+    "proxyHealth": 0
+  },
+  "powerhouse-fitness": {
+    "proxyHealth": 0
+  },
+  "snap-fitness": {
+    "proxyHealth": 0
+  },
+  "run4theh111z": {
+    "proxyHealth": 0
+  },
+  "I.I.I.I": {
+    "proxyHealth": 0
+  },
+  "avmnite-02h": {
+    "proxyHealth": 0
+  },
+  ".": {
+    "proxyHealth": 0
+  },
+  "CSEC": {
+    "proxyHealth": 0
+  },
+  "The-Cave": {
+    "proxyHealth": 0
+  },
+  "w0r1d_d43m0n": {
+    "proxyHealth": 0
+  }
+};

--- a/src/Bitrunner/data/servers.ts
+++ b/src/Bitrunner/data/servers.ts
@@ -1,4 +1,7 @@
 export const bitrunnerServerData : Record<string, Record<string, number>> = {
+  "pawnshop": {
+    "proxyHealth": 0
+  },
   "ecorp": {
     "proxyHealth": 0
   },

--- a/src/Locations/Locations.ts
+++ b/src/Locations/Locations.ts
@@ -204,7 +204,7 @@ Cities[CityName.Volhaven].asciiArt = `
               /  [computek]  |             /                                    
              /       A-------o------I-----o                                     
           1 o                |            |                                     
-                             |    [zb]    o 77                                  
+                             |    [zb]    N [johnny's pawn shop]                
                   [lexocorp] C                                                  
                              |                                                  
                              o                                                  

--- a/src/Locations/data/LocationNames.ts
+++ b/src/Locations/data/LocationNames.ts
@@ -64,6 +64,7 @@ export enum LocationName {
   VolhavenOmniaCybersystems = "Omnia Cybersystems",
   VolhavenSysCoreSecurities = "SysCore Securities",
   VolhavenZBInstituteOfTechnology = "ZB Institute of Technology",
+  VolhavenPawnShop = "Johnny's Pawn Shop",
 
   // Generic locations
   Hospital = "Hospital",

--- a/src/Locations/data/LocationsMetadata.ts
+++ b/src/Locations/data/LocationsMetadata.ts
@@ -455,4 +455,9 @@ export const LocationsMetadata: IConstructorParams[] = [
     name: LocationName.IshimaGlitch,
     types: [LocationType.Special],
   },
+  {
+    city: CityName.Volhaven,
+    name: LocationName.VolhavenPawnShop,
+    types: [LocationType.Special],
+  },
 ];

--- a/src/Locations/ui/SpecialLocation.tsx
+++ b/src/Locations/ui/SpecialLocation.tsx
@@ -334,6 +334,10 @@ export function SpecialLocation(props: IProps): React.ReactElement {
     case LocationName.NewTokyoArcade: {
       return <ArcadeRoot />;
     }
+    case LocationName.VolhavenPawnShop: {
+      return renderNoodleBar();
+    }
+
     default:
       console.error(`Location ${props.loc.name} doesn't have any special properties`);
       return <></>;

--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -73,6 +73,7 @@ import { NetscriptCorporation } from "./NetscriptFunctions/Corporation";
 import { NetscriptFormulas } from "./NetscriptFunctions/Formulas";
 import { NetscriptStockMarket } from "./NetscriptFunctions/StockMarket";
 import { NetscriptGrafting } from "./NetscriptFunctions/Grafting";
+import { NetscriptBitrunner } from "./NetscriptFunctions/Bitrunner";
 import { IPort } from "./NetscriptPort";
 
 import {
@@ -81,6 +82,7 @@ import {
   Player as INetscriptPlayer,
   Gang as IGang,
   Bladeburner as IBladeburner,
+  Bitrunner as IBitrunner,
   Stanek as IStanek,
   Infiltration as IInfiltration,
   RunningScript as IRunningScript,
@@ -114,6 +116,7 @@ interface NS extends INS {
   [key: string]: any;
   gang: IGang;
   bladeburner: IBladeburner;
+  bitrunner: IBitrunner;
   stanek: IStanek;
   infiltration: IInfiltration;
 }
@@ -541,6 +544,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
   const stockmarket = NetscriptStockMarket(Player, workerScript, helper);
   const ui = NetscriptUserInterface(Player, workerScript, helper);
   const grafting = NetscriptGrafting(Player, workerScript, helper);
+  const bitrunner = NetscriptBitrunner(Player, workerScript, helper);
 
   const base: INS = {
     ...singularity,
@@ -557,6 +561,7 @@ export function NetscriptFunctions(workerScript: WorkerScript): NS {
     formulas: formulas,
     stock: stockmarket,
     grafting: grafting,
+    bitrunner: bitrunner,
     args: workerScript.args,
     hacknet: hacknet,
     sprintf: sprintf,

--- a/src/NetscriptFunctions/Bitrunner.ts
+++ b/src/NetscriptFunctions/Bitrunner.ts
@@ -1,0 +1,38 @@
+
+import { INetscriptHelper } from "./INetscriptHelper";
+import { WorkerScript } from "../Netscript/WorkerScript";
+import { IPlayer } from "../PersonObjects/IPlayer";
+import { getRamCost } from "../Netscript/RamCostGenerator";
+import { Bitrunner as INetscriptBitrunner, bitrunnerExtension } from "../ScriptEditor/NetscriptDefinitions";
+import { GetServer } from "../Server/AllServers";
+import { Server } from "../Server/Server";
+import { BitrunnerServerExtension } from "../Bitrunner/ServerExtension";
+
+export function NetscriptBitrunner(
+  player: IPlayer,
+  workerScript: WorkerScript,
+  helper: INetscriptHelper,
+): INetscriptBitrunner {
+
+  const checkBitrunnerAccess = function (func: string): number {
+    if (player.bitNodeN === 14)
+      return player.bitNodeN;
+    else
+      throw helper.makeRuntimeErrorMsg(`bitrunner.${func}`, "You do not currently have access to the Bitrunner API. You must be in BitNode-14.");
+  }
+
+  const updateRam = (funcName: string): void =>
+    helper.updateDynamicRam(funcName, getRamCost(player, "bladeburner", funcName));
+
+  return {
+    getServerExtension: function (host?: string): bitrunnerExtension {
+      updateRam("getServerExtension");
+      checkBitrunnerAccess("getServerExtension");
+      const server = GetServer(host || workerScript.hostname);
+      if (server instanceof Server && server.modules.bitrunner instanceof BitrunnerServerExtension){
+          return server.modules.bitrunner;
+      }
+      throw helper.makeRuntimeErrorMsg(`bitrunner.getServerExtension`, "Bitrunner module is loaded incorrectly or there is a type mismatch.");
+    }
+  };
+}

--- a/src/Prestige.ts
+++ b/src/Prestige.ts
@@ -72,7 +72,7 @@ export function prestigeAugmentation(): void {
   }
 
   // Re-create foreign servers
-  initForeignServers(Player.getHomeComputer());
+  initForeignServers(Player.getHomeComputer(), Player.bitNodeN);
 
   // Gain favor for Companies
   for (const member of Object.keys(Companies)) {
@@ -194,7 +194,7 @@ export function prestigeSourceFile(flume: boolean): void {
   prestigeHomeComputer(Player, homeComp);
 
   // Re-create foreign servers
-  initForeignServers(Player.getHomeComputer());
+  initForeignServers(Player.getHomeComputer(), Player.bitNodeN);
 
   if (Player.sourceFileLvl(9) >= 2) {
     homeComp.setMaxRam(128);

--- a/src/ScriptEditor/NetscriptDefinitions.d.ts
+++ b/src/ScriptEditor/NetscriptDefinitions.d.ts
@@ -534,6 +534,16 @@ export interface Server {
   serverGrowth: number;
 }
 
+
+/**
+ * Bitrunner extension details of a single server.
+ * @public
+ */
+export interface bitrunnerExtension {
+  /** Demo value */
+  proxyHealth: number;
+}
+
 /**
  * All multipliers affecting the difficulty of the current challenge.
  * @public
@@ -1110,6 +1120,25 @@ export interface SleeveTask {
   gymStatType: string;
   /** Faction work type being performed, if any */
   factionWorkType: string;
+}
+
+
+/**
+ * Bitrunner API
+ * @public
+ */
+export interface Bitrunner {
+
+  /**
+   * Returns the Bitrunner serverExtension object for the given server.
+   * Defaults to the running script's server if host is not specified.
+   * @remarks
+   * RAM cost: 1 GB
+   *
+   * @param host - Optional. Hostname for the requested server object.
+   * @returns The requested bitrunner extension object
+   */
+  getServerExtension(host?: string): bitrunnerExtension;
 }
 
 /**
@@ -4505,6 +4534,13 @@ export interface NS {
    * RAM cost: 0 GB
    */
   readonly grafting: Grafting;
+
+  /**
+   * Namespace for bitrunner functions.
+   * @remarks
+   * RAM cost: 0 GB
+   */
+  readonly bitrunner: Bitrunner;
 
   /**
    * Arguments passed into the script.

--- a/src/Server/AllServers.ts
+++ b/src/Server/AllServers.ts
@@ -11,6 +11,7 @@ import { Reviver } from "../utils/JSONReviver";
 import { isValidIPAddress } from "../utils/helpers/isValidIPAddress";
 import { SpecialServers } from "./data/SpecialServers";
 import { BitNodeMultipliers } from "../BitNode/BitNodeMultipliers";
+import { BitrunnerServerExtension } from "../Bitrunner/ServerExtension";
 
 /**
  * Map of all Servers that exist in the game
@@ -115,7 +116,7 @@ interface IServerParams {
   [key: string]: any;
 }
 
-export function initForeignServers(homeComputer: Server): void {
+export function initForeignServers(homeComputer: Server, bitNodeN : number): void {
   /* Create a randomized network for all the foreign servers */
   //Groupings for creating a randomized network
   const networkLayers: Server[][] = [];
@@ -163,6 +164,10 @@ export function initForeignServers(homeComputer: Server): void {
     const server = new Server(serverParams);
     for (const filename of metadata.literature || []) {
       server.messages.push(filename);
+    }
+
+    if(bitNodeN === 14) {
+      server.modules.bitrunner = new BitrunnerServerExtension(server.hostname);
     }
 
     if (server.hostname === SpecialServers.WorldDaemon) {

--- a/src/Server/Server.ts
+++ b/src/Server/Server.ts
@@ -56,7 +56,6 @@ export class Server extends BaseServer {
   // be increased using the grow() Netscript function
   serverGrowth = 1;
 
-  // TODO: Limit to module class
   modules : Record<string,ServerExtension> = {}
 
   constructor(params: IConstructorParams = { hostname: "", ip: createRandomIp() }) {

--- a/src/Server/Server.ts
+++ b/src/Server/Server.ts
@@ -6,6 +6,7 @@ import { BitNodeMultipliers } from "../BitNode/BitNodeMultipliers";
 import { createRandomString } from "../utils/helpers/createRandomString";
 import { createRandomIp } from "../utils/IPAddress";
 import { Generic_fromJSON, Generic_toJSON, Reviver } from "../utils/JSONReviver";
+import { ServerExtension } from "./ServerExtension";
 
 export interface IConstructorParams {
   adminRights?: boolean;
@@ -54,6 +55,9 @@ export class Server extends BaseServer {
   // Parameter that affects how effectively this server's money can
   // be increased using the grow() Netscript function
   serverGrowth = 1;
+
+  // TODO: Limit to module class
+  modules : Record<string,ServerExtension> = {}
 
   constructor(params: IConstructorParams = { hostname: "", ip: createRandomIp() }) {
     super(params);

--- a/src/Server/ServerExtension.ts
+++ b/src/Server/ServerExtension.ts
@@ -1,0 +1,1 @@
+export class ServerExtension{}

--- a/src/Server/data/servers.ts
+++ b/src/Server/data/servers.ts
@@ -79,6 +79,23 @@ interface IServerMetadata {
 export const serverMetadata: IServerMetadata[] = [
   {
     hackDifficulty: 99,
+    hostname: "pawnshop",
+    moneyAvailable: {
+      max: 50e9,
+      min: 30e9,
+    },
+    networkLayer: 9,
+    numOpenPortsRequired: 5,
+    organizationName: LocationName.VolhavenPawnShop,
+    requiredHackingSkill: {
+      max: 1050,
+      min: 950,
+    },
+    serverGrowth: 65,
+    specialName: LocationName.VolhavenPawnShop,
+  },
+  {
+    hackDifficulty: 99,
     hostname: LocationName.AevumECorp.toLowerCase(),
     moneyAvailable: {
       max: 70e9,

--- a/src/engine.tsx
+++ b/src/engine.tsx
@@ -441,7 +441,7 @@ const Engine: {
       initBitNodeMultipliers(Player);
       Engine.start(); // Run main game loop and Scripts loop
       Player.init();
-      initForeignServers(Player.getHomeComputer());
+      initForeignServers(Player.getHomeComputer(), Player.bitNodeN);
       initCompanies();
       initFactions();
       initAugmentations();


### PR DESCRIPTION
Adds a Bitnode to the Bitverse, with default multipliers for now.
What this means in practise is that you can enter the Bitrunner Bitnode, with it behaving like BN1 for now.